### PR TITLE
Remove Giraffe dependency.  Deprecate HODI.Giraffe.DependencyInjection module

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,48 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+# All files
+[*]
+indent_style = space
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+[*.fs]
+indent_size=4
+max_line_length=120
+fsharp_semicolon_at_end_of_line=false
+fsharp_space_before_parameter=true
+fsharp_space_before_lowercase_invocation=true
+fsharp_space_before_uppercase_invocation=false
+fsharp_space_before_class_constructor=false
+fsharp_space_before_member=false
+fsharp_space_before_colon=true
+fsharp_space_after_comma=true
+fsharp_space_before_semicolon=false
+fsharp_space_after_semicolon=true
+fsharp_indent_on_try_with=false
+fsharp_space_around_delimiter=true
+fsharp_max_if_then_else_short_width=40
+fsharp_max_infix_operator_expression=50
+fsharp_max_record_width=40
+fsharp_max_record_number_of_items=1
+fsharp_record_multiline_formatter=character_width
+fsharp_max_array_or_list_width=40
+fsharp_max_array_or_list_number_of_items=1
+fsharp_array_or_list_multiline_formatter=character_width
+fsharp_max_value_binding_width=40
+fsharp_max_function_binding_width=40
+fsharp_max_dot_get_expression_width=50
+fsharp_multiline_block_brackets_on_same_column=false
+fsharp_newline_between_type_definition_and_members=false
+fsharp_keep_if_then_in_same_line=false
+fsharp_max_elmish_width=40
+fsharp_single_argument_web_mode=false
+fsharp_align_function_signature_to_indentation=false
+fsharp_alternative_long_member_definitions=false
+fsharp_multi_line_lambda_closing_newline=false
+fsharp_disable_elmish_syntax=false
+fsharp_keep_indent_in_branch=false
+fsharp_blank_lines_around_nested_multiline_expressions=true
+fsharp_strict_mode=false

--- a/src/HODI/DependencyInjection.fs
+++ b/src/HODI/DependencyInjection.fs
@@ -1,0 +1,282 @@
+﻿namespace HODI
+
+open System.Threading.Tasks
+
+open Microsoft.AspNetCore.Http
+
+
+/// <summary>
+/// A set of functions used to inject dependencies into higher order functions.
+/// </summary>
+module DependencyInjection =
+
+
+    /// <summary>
+    /// Gets a dependency from the DI container and provides it to the supplied handler.
+    ///
+    /// Types can be inferred making the code below possible:
+    ///
+    /// funcWithADependency |> <see cref="inject" />
+    /// </summary>
+    let inject (handler : 'Dep -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+               (next : HttpContext -> Task<HttpContext option>)
+               (ctx : HttpContext)
+               : Task<HttpContext option> =
+        let dep =
+            ctx.RequestServices.GetService(typeof<'Dep>) :?> 'Dep
+
+        handler dep next ctx
+
+    /// <summary>
+    /// Gets 2 dependencies from the DI container and provides them to the supplied handler.
+    ///
+    /// Type inference makes the following possible:
+    ///
+    /// funcWith2Dependencies |> <see cref="inject2" />
+    /// </summary>
+    let inject2 (handler : 'Dep0 -> 'Dep1 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                (next : HttpContext -> Task<HttpContext option>)
+                (ctx : HttpContext)
+                : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        handler dep0 dep1 next ctx
+
+    /// <summary>
+    /// Gets 3 dependencies from the DI container and provides them to the supplied handler.
+    ///
+    /// Type inference makes the following possible:
+    ///
+    /// funcWith3Dependencies |> <see cref="inject3" />
+    /// </summary>
+    let inject3 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                (next : HttpContext -> Task<HttpContext option>)
+                (ctx : HttpContext)
+                : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        handler dep0 dep1 dep2 next ctx
+
+    /// <summary>
+    /// Gets 4 dependencies from the DI container and provides them to the supplied handler.
+    ///
+    /// Type inference makes the following possible:
+    ///
+    /// funcWith4Dependencies |> <see cref="inject4" />
+    /// </summary>
+    let inject4 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                (next : HttpContext -> Task<HttpContext option>)
+                (ctx : HttpContext)
+                : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        let dep3 =
+            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+
+        handler dep0 dep1 dep2 dep3 next ctx
+
+    /// <summary>
+    /// Gets 5 dependencies from the DI container and provides them to the supplied handler.
+    ///
+    /// Type inference makes the following possible:
+    ///
+    /// funcWith5Dependencies |> <see cref="inject5" />
+    /// </summary>
+    let inject5 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                (next : HttpContext -> Task<HttpContext option>)
+                (ctx : HttpContext)
+                : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        let dep3 =
+            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+
+        let dep4 =
+            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+
+        handler dep0 dep1 dep2 dep3 dep4 next ctx
+
+    /// <summary>
+    /// Gets 6 dependencies from the DI container and provides them to the supplied handler.
+    ///
+    /// Type inference makes the following possible:
+    ///
+    /// funcWith6Dependencies |> <see cref="inject6" />
+    /// </summary>
+    let inject6 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                (next : HttpContext -> Task<HttpContext option>)
+                (ctx : HttpContext)
+                : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        let dep3 =
+            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+
+        let dep4 =
+            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+
+        let dep5 =
+            ctx.RequestServices.GetService(typeof<'Dep5>) :?> 'Dep5
+
+        handler dep0 dep1 dep2 dep3 dep4 dep5 next ctx
+
+    /// <summary>
+    /// Gets 7 dependencies from the DI container and provides them to the supplied handler.
+    ///
+    /// Type inference makes the following possible:
+    ///
+    /// funcWith7Dependencies |> <see cref="inject7" />
+    /// </summary>
+    let inject7 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> 'Dep6 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                (next : HttpContext -> Task<HttpContext option>)
+                (ctx : HttpContext)
+                : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        let dep3 =
+            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+
+        let dep4 =
+            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+
+        let dep5 =
+            ctx.RequestServices.GetService(typeof<'Dep5>) :?> 'Dep5
+
+        let dep6 =
+            ctx.RequestServices.GetService(typeof<'Dep6>) :?> 'Dep6
+
+        handler dep0 dep1 dep2 dep3 dep4 dep5 dep6 next ctx
+
+    /// <summary>
+    /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with a dependency to the supplied handler.
+    /// </summary>
+    let injectPlus<'T, 'Dep> (handler : 'T -> 'Dep -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                             (model : 'T)
+                             (next : HttpContext -> Task<HttpContext option>)
+                             (ctx : HttpContext)
+                             : Task<HttpContext option> =
+        let dep =
+            ctx.RequestServices.GetService(typeof<'Dep>) :?> 'Dep
+
+        handler model dep next ctx
+
+    /// <summary>
+    /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 2 dependencies to the supplied handler.
+    /// </summary>
+    let inject2Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                    (model : 'T)
+                    (next : HttpContext -> Task<HttpContext option>)
+                    (ctx : HttpContext)
+                    : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        handler model dep0 dep1 next ctx
+
+    /// <summary>
+    /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 3 dependencies to the supplied handler.
+    /// </summary>
+    let inject3Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                    (model : 'T)
+                    (next : HttpContext -> Task<HttpContext option>)
+                    (ctx : HttpContext)
+                    : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        handler model dep0 dep1 dep2 next ctx
+
+    /// <summary>
+    /// Passes given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 4 dependencies and provides them to the supplied handler.
+    /// </summary>
+    let inject4Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                    (model : 'T)
+                    (next : HttpContext -> Task<HttpContext option>)
+                    (ctx : HttpContext)
+                    : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        let dep3 =
+            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+
+        handler model dep0 dep1 dep2 dep3 next ctx
+
+    /// <summary>
+    /// Passes given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 5 dependencies and provides them to the supplied handler.
+    /// </summary>
+    let inject5Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
+                    (model : 'T)
+                    (next : HttpContext -> Task<HttpContext option>)
+                    (ctx : HttpContext)
+                    : Task<HttpContext option> =
+        let dep0 =
+            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
+
+        let dep1 =
+            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+
+        let dep2 =
+            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+
+        let dep3 =
+            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+
+        let dep4 =
+            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+
+        handler model dep0 dep1 dep2 dep3 dep4 next ctx

--- a/src/HODI/Giraffe/DependencyInjection.fs
+++ b/src/HODI/Giraffe/DependencyInjection.fs
@@ -1,11 +1,13 @@
 ﻿/// <summary>
 /// A set of functions used to inject dependencies into higher order functions.
+///
+/// This module is obsolute.
+/// Use the HODI.DependencyInjection module instead
 /// </summary>
 module HODI.Giraffe.DependencyInjection
 
-    
-open Microsoft.AspNetCore.Http
-open Giraffe
+open System
+open System.Diagnostics.CodeAnalysis
 
 /// <summary>
 /// Gets a dependency from the DI container and provides it to the supplied handler.
@@ -14,9 +16,10 @@ open Giraffe
 ///
 /// funcWithADependency |> <see cref="inject" />
 /// </summary>
-let inject (handler : 'Dep -> HttpHandler) (next : HttpFunc) (ctx : HttpContext) : HttpFuncResult =
-    let dep = ctx.GetService<'Dep>()
-    handler dep next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject = HODI.DependencyInjection.inject
+
 
 /// <summary>
 /// Gets 2 dependencies from the DI container and provides them to the supplied handler.
@@ -25,10 +28,10 @@ let inject (handler : 'Dep -> HttpHandler) (next : HttpFunc) (ctx : HttpContext)
 ///
 /// funcWith2Dependencies |> <see cref="inject2" />
 /// </summary>
-let inject2 (handler : 'Dep0 -> 'Dep1 -> HttpHandler) (next : HttpFunc) (ctx : HttpContext) : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    handler dep0 dep1 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject2 = HODI.DependencyInjection.inject2
+
 
 /// <summary>
 /// Gets 3 dependencies from the DI container and provides them to the supplied handler.
@@ -37,11 +40,10 @@ let inject2 (handler : 'Dep0 -> 'Dep1 -> HttpHandler) (next : HttpFunc) (ctx : H
 ///
 /// funcWith3Dependencies |> <see cref="inject3" />
 /// </summary>
-let inject3 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> HttpHandler) (next : HttpFunc) (ctx : HttpContext) : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    handler dep0 dep1 dep2 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject3 = HODI.DependencyInjection.inject3
+
 
 /// <summary>
 /// Gets 4 dependencies from the DI container and provides them to the supplied handler.
@@ -50,15 +52,10 @@ let inject3 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> HttpHandler) (next : HttpFunc)
 ///
 /// funcWith4Dependencies |> <see cref="inject4" />
 /// </summary>
-let inject4 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> HttpHandler)
-            (next : HttpFunc)
-            (ctx : HttpContext)
-            : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    let dep3 = ctx.GetService<'Dep3>()
-    handler dep0 dep1 dep2 dep3 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject4 = HODI.DependencyInjection.inject4
+
 
 /// <summary>
 /// Gets 5 dependencies from the DI container and provides them to the supplied handler.
@@ -67,16 +64,10 @@ let inject4 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> HttpHandler)
 ///
 /// funcWith5Dependencies |> <see cref="inject5" />
 /// </summary>
-let inject5 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> HttpHandler)
-            (next : HttpFunc)
-            (ctx : HttpContext)
-            : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    let dep3 = ctx.GetService<'Dep3>()
-    let dep4 = ctx.GetService<'Dep4>()
-    handler dep0 dep1 dep2 dep3 dep4 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject5 = HODI.DependencyInjection.inject5
+
 
 /// <summary>
 /// Gets 6 dependencies from the DI container and provides them to the supplied handler.
@@ -85,17 +76,10 @@ let inject5 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> HttpHandler)
 ///
 /// funcWith6Dependencies |> <see cref="inject6" />
 /// </summary>
-let inject6 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> HttpHandler)
-            (next : HttpFunc)
-            (ctx : HttpContext)
-            : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    let dep3 = ctx.GetService<'Dep3>()
-    let dep4 = ctx.GetService<'Dep4>()
-    let dep5 = ctx.GetService<'Dep5>()
-    handler dep0 dep1 dep2 dep3 dep4 dep5 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject6 = HODI.DependencyInjection.inject6
+
 
 /// <summary>
 /// Gets 7 dependencies from the DI container and provides them to the supplied handler.
@@ -104,76 +88,46 @@ let inject6 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> Htt
 ///
 /// funcWith7Dependencies |> <see cref="inject7" />
 /// </summary>
-let inject7 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> 'Dep6 -> HttpHandler)
-            (next : HttpFunc)
-            (ctx : HttpContext)
-            : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    let dep3 = ctx.GetService<'Dep3>()
-    let dep4 = ctx.GetService<'Dep4>()
-    let dep5 = ctx.GetService<'Dep5>()
-    let dep6 = ctx.GetService<'Dep6>()
-    handler dep0 dep1 dep2 dep3 dep4 dep5 dep6 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject7 = HODI.DependencyInjection.inject7
+
 
 /// <summary>
 /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with a dependency to the supplied handler.
 /// </summary>
-let injectPlus<'T, 'Dep> (handler : 'T -> 'Dep -> HttpHandler) (model : 'T) (next : HttpFunc) (ctx : HttpContext) : HttpFuncResult =
-    let dep = ctx.GetService<'Dep>()
-    handler model dep next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let injectPlus = HODI.DependencyInjection.injectPlus
+
 
 /// <summary>
 /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 2 dependencies to the supplied handler.
 /// </summary>
-let inject2Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> HttpHandler)
-                (model : 'T)
-                (next : HttpFunc)
-                (ctx : HttpContext)
-                    : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    handler model dep0 dep1 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject2Plus = HODI.DependencyInjection.inject2Plus
+
 
 /// <summary>
 /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 3 dependencies to the supplied handler.
 /// </summary>
-let inject3Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> HttpHandler)
-                        (model : 'T)
-                        (next : HttpFunc)
-                        (ctx : HttpContext)
-                        : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    handler model dep0 dep1 dep2 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject3Plus = HODI.DependencyInjection.inject3Plus
+
 
 /// <summary>
 /// Passes given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 4 dependencies and provides them to the supplied handler.
 /// </summary>
-let inject4Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> HttpHandler)
-                (model : 'T)
-                (next : HttpFunc)
-                (ctx : HttpContext)
-                : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    let dep3 = ctx.GetService<'Dep3>()
-    handler model dep0 dep1 dep2 dep3 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject4Plus = HODI.DependencyInjection.inject4Plus
+
 
 /// <summary>
 /// Passes given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 5 dependencies and provides them to the supplied handler.
 /// </summary>
-let inject5Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> HttpHandler)
-                        (model : 'T)
-                        (next : HttpFunc)
-                        (ctx : HttpContext)
-                        : HttpFuncResult =
-    let dep0 = ctx.GetService<'Dep0>()
-    let dep1 = ctx.GetService<'Dep1>()
-    let dep2 = ctx.GetService<'Dep2>()
-    let dep3 = ctx.GetService<'Dep3>()
-    let dep4 = ctx.GetService<'Dep4>()
-    handler model dep0 dep1 dep2 dep3 dep4 next ctx
+[<Obsolete("Use the functions in the HODI.DependencyInjection module instead")>]
+[<ExcludeFromCodeCoverage>]
+let inject5Plus = HODI.DependencyInjection.inject5Plus

--- a/src/HODI/HODI.fsproj
+++ b/src/HODI/HODI.fsproj
@@ -13,15 +13,12 @@
     <PackageTags>F#, FSharp, dependency injection, giraffe</PackageTags>
     <SignAssembly>false</SignAssembly>
     <PackageIcon>hodi.png</PackageIcon>
-    <Version>1.0.3</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="DependencyInjection.fs" />
     <Compile Include="Giraffe\DependencyInjection.fs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Giraffe" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,6 +30,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/HODI.Tests/GiraffeTests.fs
+++ b/tests/HODI.Tests/GiraffeTests.fs
@@ -1,17 +1,18 @@
 module HODI.Tests
 
-open Microsoft.AspNetCore.Http
-open Microsoft.Extensions.DependencyInjection
+open System.Threading.Tasks
 
-open Giraffe.Core
+open Microsoft.AspNetCore.Http
+
+open Microsoft.Extensions.DependencyInjection
 
 open NSubstitute
 
 open NUnit.Framework
 
+open HODI.DependencyInjection
 
-open HODI.Giraffe.DependencyInjection
-
+type HttpFunc = HttpContext -> Task<HttpContext option>
 
 let next = Substitute.For<HttpFunc>()
 
@@ -42,8 +43,9 @@ type FakeDependency6() =
 [<Test>]
 let ``The inject function should get a dependency from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject
+
     let givenHandler =
-        fun (dep: FakeDependency0) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) next (ctx : HttpContext) ->
             dep.AssertCreated()
             next ctx
 
@@ -59,10 +61,11 @@ let ``The inject function should get a dependency from the service container and
 
 
 [<Test>]
-let ``The inject2 function should get 2 dependenies from the service container and pass it to the given handler``() =
+let ``The inject2 function should get 2 dependenies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject2
+
     let givenHandler =
-        fun (dep: FakeDependency0) (dep2: FakeDependency1) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) (dep2 : FakeDependency1) next (ctx : HttpContext) ->
             dep.AssertCreated()
             dep2.AssertCreated()
             next ctx
@@ -79,10 +82,11 @@ let ``The inject2 function should get 2 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject3 function should get 3 dependenies from the service container and pass it to the given handler``() =
+let ``The inject3 function should get 3 dependenies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject3
+
     let givenHandler =
-        fun (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) next (ctx : HttpContext) ->
             dep.AssertCreated()
             dep2.AssertCreated()
             dep3.AssertCreated()
@@ -101,10 +105,11 @@ let ``The inject3 function should get 3 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject4 function should get 4 dependenies from the service container and pass it to the given handler``() =
+let ``The inject4 function should get 4 dependenies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject4
+
     let givenHandler =
-        fun (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) (dep4: FakeDependency3) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) (dep4 : FakeDependency3) next (ctx : HttpContext) ->
             dep.AssertCreated()
             dep2.AssertCreated()
             dep3.AssertCreated()
@@ -125,10 +130,11 @@ let ``The inject4 function should get 4 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject5 function should get 5 dependenies from the service container and pass it to the given handler``() =
+let ``The inject5 function should get 5 dependenies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject5
+
     let givenHandler =
-        fun (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) (dep4: FakeDependency3) (dep5: FakeDependency4) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) (dep4 : FakeDependency3) (dep5 : FakeDependency4) next (ctx : HttpContext) ->
             dep.AssertCreated()
             dep2.AssertCreated()
             dep3.AssertCreated()
@@ -152,10 +158,11 @@ let ``The inject5 function should get 5 dependenies from the service container a
 
 
 [<Test>]
-let ``The inject6 function should get 6 dependenies from the service container and pass it to the given handler``() =
+let ``The inject6 function should get 6 dependenies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject6
+
     let givenHandler =
-        fun (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) (dep4: FakeDependency3) (dep5: FakeDependency4) (dep6: FakeDependency5) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) (dep4 : FakeDependency3) (dep5 : FakeDependency4) (dep6 : FakeDependency5) next (ctx : HttpContext) ->
             dep.AssertCreated()
             dep2.AssertCreated()
             dep3.AssertCreated()
@@ -180,10 +187,11 @@ let ``The inject6 function should get 6 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject7 function should get 7 dependenies from the service container and pass it to the given handler``() =
+let ``The inject7 function should get 7 dependenies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject7
+
     let givenHandler =
-        fun (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) (dep4: FakeDependency3) (dep5: FakeDependency4) (dep6: FakeDependency5) (dep7: FakeDependency6) next (ctx: HttpContext) ->
+        fun (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) (dep4 : FakeDependency3) (dep5 : FakeDependency4) (dep6 : FakeDependency5) (dep7 : FakeDependency6) next (ctx : HttpContext) ->
             dep.AssertCreated()
             dep2.AssertCreated()
             dep3.AssertCreated()
@@ -211,10 +219,12 @@ let ``The inject7 function should get 7 dependenies from the service container a
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The injectPlus function should get a dependency from the service container and pass them and an additional argument to the given handler``  givenAdditionalArgument =
+let ``The injectPlus function should get a dependency from the service container and pass them and an additional argument to the given handler`` givenAdditionalArgument
+                                                                                                                                                 =
     let systemUnderTest = injectPlus
+
     let givenHandler =
-        fun (addl: string) (dep: FakeDependency0) next (ctx: HttpContext) ->
+        fun (addl : string) (dep : FakeDependency0) next (ctx : HttpContext) ->
             Assert.AreEqual(givenAdditionalArgument, addl)
             dep.AssertCreated()
             next ctx
@@ -232,10 +242,12 @@ let ``The injectPlus function should get a dependency from the service container
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject2Plus function should get 2 dependenies from the service container and pass it and an additional argument to the given handler`` givenAdditionalArgument =
+let ``The inject2Plus function should get 2 dependenies from the service container and pass it and an additional argument to the given handler`` givenAdditionalArgument
+                                                                                                                                                 =
     let systemUnderTest = inject2Plus
+
     let givenHandler =
-        fun (addl: string) (dep: FakeDependency0) (dep2: FakeDependency1) next (ctx: HttpContext) ->
+        fun (addl : string) (dep : FakeDependency0) (dep2 : FakeDependency1) next (ctx : HttpContext) ->
             Assert.AreEqual(givenAdditionalArgument, addl)
             dep.AssertCreated()
             dep2.AssertCreated()
@@ -254,10 +266,12 @@ let ``The inject2Plus function should get 2 dependenies from the service contain
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject3Plus function should get 3 dependenies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument =
+let ``The inject3Plus function should get 3 dependenies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument
+                                                                                                                                             =
     let systemUnderTest = inject3Plus
+
     let givenHandler =
-        fun (addl: string) (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) next (ctx: HttpContext) ->
+        fun (addl : string) (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) next (ctx : HttpContext) ->
             Assert.AreEqual(givenAdditionalArgument, addl)
             dep.AssertCreated()
             dep2.AssertCreated()
@@ -278,10 +292,12 @@ let ``The inject3Plus function should get 3 dependenies from the service contain
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject4Plus function should get 4 dependenies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument =
+let ``The inject4Plus function should get 4 dependenies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument
+                                                                                                                                             =
     let systemUnderTest = inject4Plus
+
     let givenHandler =
-        fun (addl: string) (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) (dep4: FakeDependency3) next (ctx: HttpContext) ->
+        fun (addl : string) (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) (dep4 : FakeDependency3) next (ctx : HttpContext) ->
             Assert.AreEqual(givenAdditionalArgument, addl)
             dep.AssertCreated()
             dep2.AssertCreated()
@@ -304,10 +320,12 @@ let ``The inject4Plus function should get 4 dependenies from the service contain
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject5Plus function should get 5 dependenies from the service container and pass them and another arguments to the given handler`` givenAdditionalArgument =
+let ``The inject5Plus function should get 5 dependenies from the service container and pass them and another arguments to the given handler`` givenAdditionalArgument
+                                                                                                                                              =
     let systemUnderTest = inject5Plus
+
     let givenHandler =
-        fun (addl: string) (dep: FakeDependency0) (dep2: FakeDependency1) (dep3: FakeDependency2) (dep4: FakeDependency3) (dep5: FakeDependency4) next (ctx: HttpContext) ->
+        fun (addl : string) (dep : FakeDependency0) (dep2 : FakeDependency1) (dep3 : FakeDependency2) (dep4 : FakeDependency3) (dep5 : FakeDependency4) next (ctx : HttpContext) ->
             Assert.AreEqual(givenAdditionalArgument, addl)
             dep.AssertCreated()
             dep2.AssertCreated()

--- a/tests/HODI.Tests/HODI.Tests.fsproj
+++ b/tests/HODI.Tests/HODI.Tests.fsproj
@@ -12,7 +12,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Giraffe" Version="4.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/tests/HODI.Tests/Program.fs
+++ b/tests/HODI.Tests/Program.fs
@@ -1,1 +1,3 @@
-module Program = let [<EntryPoint>] main _ = 0
+module Program =
+    [<EntryPoint>]
+    let main _ = 0


### PR DESCRIPTION
Removing the dependency on Giraffe so that this library can be used by itself without the added overhead.