### PR TITLE
Refactor service retrieval implementation.

### DIFF
--- a/src/HODI/DependencyInjection.fs
+++ b/src/HODI/DependencyInjection.fs
@@ -3,13 +3,12 @@
 open System.Threading.Tasks
 
 open Microsoft.AspNetCore.Http
-
+open Microsoft.Extensions.DependencyInjection
 
 /// <summary>
 /// A set of functions used to inject dependencies into higher order functions.
 /// </summary>
 module DependencyInjection =
-
 
     /// <summary>
     /// Gets a dependency from the DI container and provides it to the supplied handler.
@@ -18,12 +17,16 @@ module DependencyInjection =
     ///
     /// funcWithADependency |> <see cref="inject" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject (handler : 'Dep -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                (next : HttpContext -> Task<HttpContext option>)
                (ctx : HttpContext)
                : Task<HttpContext option> =
+
         let dep =
-            ctx.RequestServices.GetService(typeof<'Dep>) :?> 'Dep
+            ctx.RequestServices.GetRequiredService<'Dep>()
 
         handler dep next ctx
 
@@ -34,15 +37,19 @@ module DependencyInjection =
     ///
     /// funcWith2Dependencies |> <see cref="inject2" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject2 (handler : 'Dep0 -> 'Dep1 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                 (next : HttpContext -> Task<HttpContext option>)
                 (ctx : HttpContext)
                 : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
+
+        let dep0 = services.GetRequiredService<'Dep0>()
+
+        let dep1 = services.GetRequiredService<'Dep1>()
 
         handler dep0 dep1 next ctx
 
@@ -53,18 +60,21 @@ module DependencyInjection =
     ///
     /// funcWith3Dependencies |> <see cref="inject3" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject3 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                 (next : HttpContext -> Task<HttpContext option>)
                 (ctx : HttpContext)
                 : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
+
+        let dep1 = services.GetRequiredService<'Dep1>()
+
+        let dep2 = services.GetRequiredService<'Dep2>()
 
         handler dep0 dep1 dep2 next ctx
 
@@ -75,21 +85,23 @@ module DependencyInjection =
     ///
     /// funcWith4Dependencies |> <see cref="inject4" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject4 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                 (next : HttpContext -> Task<HttpContext option>)
                 (ctx : HttpContext)
                 : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
 
-        let dep3 =
-            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+        let dep1 = services.GetRequiredService<'Dep1>()
+
+        let dep2 = services.GetRequiredService<'Dep2>()
+
+        let dep3 = services.GetRequiredService<'Dep3>()
 
         handler dep0 dep1 dep2 dep3 next ctx
 
@@ -100,24 +112,25 @@ module DependencyInjection =
     ///
     /// funcWith5Dependencies |> <see cref="inject5" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject5 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                 (next : HttpContext -> Task<HttpContext option>)
                 (ctx : HttpContext)
                 : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
 
-        let dep3 =
-            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+        let dep1 = services.GetRequiredService<'Dep1>()
 
-        let dep4 =
-            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+        let dep2 = services.GetRequiredService<'Dep2>()
+
+        let dep3 = services.GetRequiredService<'Dep3>()
+
+        let dep4 = services.GetRequiredService<'Dep4>()
 
         handler dep0 dep1 dep2 dep3 dep4 next ctx
 
@@ -128,27 +141,27 @@ module DependencyInjection =
     ///
     /// funcWith6Dependencies |> <see cref="inject6" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject6 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                 (next : HttpContext -> Task<HttpContext option>)
                 (ctx : HttpContext)
                 : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
 
-        let dep3 =
-            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+        let dep1 = services.GetRequiredService<'Dep1>()
 
-        let dep4 =
-            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+        let dep2 = services.GetRequiredService<'Dep2>()
 
-        let dep5 =
-            ctx.RequestServices.GetService(typeof<'Dep5>) :?> 'Dep5
+        let dep3 = services.GetRequiredService<'Dep3>()
+
+        let dep4 = services.GetRequiredService<'Dep4>()
+
+        let dep5 = services.GetRequiredService<'Dep5>()
 
         handler dep0 dep1 dep2 dep3 dep4 dep5 next ctx
 
@@ -159,124 +172,137 @@ module DependencyInjection =
     ///
     /// funcWith7Dependencies |> <see cref="inject7" />
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject7 (handler : 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> 'Dep5 -> 'Dep6 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                 (next : HttpContext -> Task<HttpContext option>)
                 (ctx : HttpContext)
                 : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
 
-        let dep3 =
-            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+        let dep1 = services.GetRequiredService<'Dep1>()
 
-        let dep4 =
-            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+        let dep2 = services.GetRequiredService<'Dep2>()
 
-        let dep5 =
-            ctx.RequestServices.GetService(typeof<'Dep5>) :?> 'Dep5
+        let dep3 = services.GetRequiredService<'Dep3>()
 
-        let dep6 =
-            ctx.RequestServices.GetService(typeof<'Dep6>) :?> 'Dep6
+        let dep4 = services.GetRequiredService<'Dep4>()
+
+        let dep5 = services.GetRequiredService<'Dep5>()
+
+        let dep6 = services.GetRequiredService<'Dep6>()
 
         handler dep0 dep1 dep2 dep3 dep4 dep5 dep6 next ctx
 
     /// <summary>
     /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with a dependency to the supplied handler.
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let injectPlus<'T, 'Dep> (handler : 'T -> 'Dep -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                              (model : 'T)
                              (next : HttpContext -> Task<HttpContext option>)
                              (ctx : HttpContext)
                              : Task<HttpContext option> =
+
         let dep =
-            ctx.RequestServices.GetService(typeof<'Dep>) :?> 'Dep
+            ctx.RequestServices.GetRequiredService<'Dep>()
 
         handler model dep next ctx
 
     /// <summary>
     /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 2 dependencies to the supplied handler.
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject2Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                     (model : 'T)
                     (next : HttpContext -> Task<HttpContext option>)
                     (ctx : HttpContext)
                     : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
+
+        let dep0 = services.GetRequiredService<'Dep0>()
+
+        let dep1 = services.GetRequiredService<'Dep1>()
 
         handler model dep0 dep1 next ctx
 
     /// <summary>
     /// Provides a given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 3 dependencies to the supplied handler.
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject3Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                     (model : 'T)
                     (next : HttpContext -> Task<HttpContext option>)
                     (ctx : HttpContext)
                     : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
+
+        let dep1 = services.GetRequiredService<'Dep1>()
+
+        let dep2 = services.GetRequiredService<'Dep2>()
 
         handler model dep0 dep1 dep2 next ctx
 
     /// <summary>
     /// Passes given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 4 dependencies and provides them to the supplied handler.
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject4Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                     (model : 'T)
                     (next : HttpContext -> Task<HttpContext option>)
                     (ctx : HttpContext)
                     : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
 
-        let dep3 =
-            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+        let dep1 = services.GetRequiredService<'Dep1>()
+
+        let dep2 = services.GetRequiredService<'Dep2>()
+
+        let dep3 = services.GetRequiredService<'Dep3>()
 
         handler model dep0 dep1 dep2 dep3 next ctx
 
     /// <summary>
     /// Passes given value (e.g. the result of a <see cref="routef" /> or <see cref="bindForm" />) along with 5 dependencies and provides them to the supplied handler.
     /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// There is no service of requested type
+    /// </exception>
     let inject5Plus (handler : 'T -> 'Dep0 -> 'Dep1 -> 'Dep2 -> 'Dep3 -> 'Dep4 -> (HttpContext -> Task<HttpContext option>) -> (HttpContext -> Task<HttpContext option>))
                     (model : 'T)
                     (next : HttpContext -> Task<HttpContext option>)
                     (ctx : HttpContext)
                     : Task<HttpContext option> =
-        let dep0 =
-            ctx.RequestServices.GetService(typeof<'Dep0>) :?> 'Dep0
 
-        let dep1 =
-            ctx.RequestServices.GetService(typeof<'Dep1>) :?> 'Dep1
+        let services = ctx.RequestServices
 
-        let dep2 =
-            ctx.RequestServices.GetService(typeof<'Dep2>) :?> 'Dep2
+        let dep0 = services.GetRequiredService<'Dep0>()
 
-        let dep3 =
-            ctx.RequestServices.GetService(typeof<'Dep3>) :?> 'Dep3
+        let dep1 = services.GetRequiredService<'Dep1>()
 
-        let dep4 =
-            ctx.RequestServices.GetService(typeof<'Dep4>) :?> 'Dep4
+        let dep2 = services.GetRequiredService<'Dep2>()
+
+        let dep3 = services.GetRequiredService<'Dep3>()
+
+        let dep4 = services.GetRequiredService<'Dep4>()
 
         handler model dep0 dep1 dep2 dep3 dep4 next ctx

--- a/src/HODI/HODI.fsproj
+++ b/src/HODI/HODI.fsproj
@@ -13,7 +13,10 @@
     <PackageTags>F#, FSharp, dependency injection, giraffe</PackageTags>
     <SignAssembly>false</SignAssembly>
     <PackageIcon>hodi.png</PackageIcon>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
+    <PackageReleaseNotes>Functions now throw InvalidOperationException if a requested type does not exist.
+Reducing the number of calls to IServiceProvider::get_RequestServices.
+Minor refactoring.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/HODI.Tests/DependencyInjectionTests.fs
+++ b/tests/HODI.Tests/DependencyInjectionTests.fs
@@ -59,7 +59,7 @@ let ``The inject function should get a dependency from the service container and
 
 
 [<Test>]
-let ``The inject2 function should get 2 dependenies from the service container and pass it to the given handler`` () =
+let ``The inject2 function should get 2 dependencies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject2
 
     let givenHandler =
@@ -80,7 +80,7 @@ let ``The inject2 function should get 2 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject3 function should get 3 dependenies from the service container and pass it to the given handler`` () =
+let ``The inject3 function should get 3 dependencies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject3
 
     let givenHandler =
@@ -103,7 +103,7 @@ let ``The inject3 function should get 3 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject4 function should get 4 dependenies from the service container and pass it to the given handler`` () =
+let ``The inject4 function should get 4 dependencies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject4
 
     let givenHandler =
@@ -128,7 +128,7 @@ let ``The inject4 function should get 4 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject5 function should get 5 dependenies from the service container and pass it to the given handler`` () =
+let ``The inject5 function should get 5 dependencies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject5
 
     let givenHandler =
@@ -156,7 +156,7 @@ let ``The inject5 function should get 5 dependenies from the service container a
 
 
 [<Test>]
-let ``The inject6 function should get 6 dependenies from the service container and pass it to the given handler`` () =
+let ``The inject6 function should get 6 dependencies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject6
 
     let givenHandler =
@@ -185,7 +185,7 @@ let ``The inject6 function should get 6 dependenies from the service container a
     |> ignore
 
 [<Test>]
-let ``The inject7 function should get 7 dependenies from the service container and pass it to the given handler`` () =
+let ``The inject7 function should get 7 dependencies from the service container and pass it to the given handler`` () =
     let systemUnderTest = inject7
 
     let givenHandler =
@@ -240,7 +240,7 @@ let ``The injectPlus function should get a dependency from the service container
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject2Plus function should get 2 dependenies from the service container and pass it and an additional argument to the given handler`` givenAdditionalArgument
+let ``The inject2Plus function should get 2 dependencies from the service container and pass it and an additional argument to the given handler`` givenAdditionalArgument
                                                                                                                                                  =
     let systemUnderTest = inject2Plus
 
@@ -264,7 +264,7 @@ let ``The inject2Plus function should get 2 dependenies from the service contain
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject3Plus function should get 3 dependenies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument
+let ``The inject3Plus function should get 3 dependencies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument
                                                                                                                                              =
     let systemUnderTest = inject3Plus
 
@@ -290,7 +290,7 @@ let ``The inject3Plus function should get 3 dependenies from the service contain
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject4Plus function should get 4 dependenies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument
+let ``The inject4Plus function should get 4 dependencies from the service container and pass them and another argument to the given handler`` givenAdditionalArgument
                                                                                                                                              =
     let systemUnderTest = inject4Plus
 
@@ -318,7 +318,7 @@ let ``The inject4Plus function should get 4 dependenies from the service contain
 
 [<Test>]
 [<TestCase("This is a string")>]
-let ``The inject5Plus function should get 5 dependenies from the service container and pass them and another arguments to the given handler`` givenAdditionalArgument
+let ``The inject5Plus function should get 5 dependencies from the service container and pass them and another arguments to the given handler`` givenAdditionalArgument
                                                                                                                                               =
     let systemUnderTest = inject5Plus
 


### PR DESCRIPTION
The functions are now calling <code>IServiceProvider::GetRequiredService</code> instead of <code>IServiceProvider::GetService</code>.

1. Throws <code>InvalidOperationException</code> if the requested service is not in the container
2. Reducing the times <code>HttpContext::RequestServices</code> property is accessed.

- [x] IServiceProvider::GetRequiredService
- [x] ~IServiceProvider::GetService~
- [x] InvalidOperationException 