### PR TITLE
build(HODI.fsproj): allow fsharp 6.0 as dependency

### DIFF
--- a/src/HODI/HODI.fsproj
+++ b/src/HODI/HODI.fsproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.*" />
+    <PackageReference Update="FSharp.Core" Version="[6.0,7.0]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some projects may still be on Fsharp.Core version 6.0.*.