### PR TITLE
feat: widen version constraints

### DIFF
--- a/src/HODI/HODI.fsproj
+++ b/src/HODI/HODI.fsproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Eric Fortmeyer</Authors>
     <Description>A set of functions used to inject dependencies into HTTP handlers in F# web applications.</Description>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="[6.0,7.0.400]" />
+    <PackageReference Update="FSharp.Core" Version="[6.0,)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +42,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.2,)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[7.0,)" />
   </ItemGroup>
 
 </Project>

--- a/tests/HODI.Tests/HODI.Tests.fsproj
+++ b/tests/HODI.Tests/HODI.Tests.fsproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
     <Version>2.0.6</Version>
@@ -14,8 +13,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="[2.2,)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[7.0,)" />
     <PackageReference Include="NSubstitute" Version="*" />
     <PackageReference Include="NUnit" Version="*" />
     <PackageReference Include="NUnit3TestAdapter" Version="*" />
@@ -32,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="[6.0,7.0.400]" />
+    <PackageReference Update="FSharp.Core" Version="[6.0,)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The following warning is displaying: "Detected package version outside of dependency constraint: HODI 2.1.1 requires FSharp.Core (>= 6.0.0 && <= 7.0.400) but version FSharp.Core 7.0.403 was resolved."